### PR TITLE
add ability to add photo url to survey

### DIFF
--- a/app/controllers/surveys.rb
+++ b/app/controllers/surveys.rb
@@ -13,7 +13,10 @@ end
 
 post '/surveys' do
   user = User.find(session[:user_id])
-  new_survey = user.surveys.create(user_id: user.id, title: params[:title])
+  new_survey = user.surveys.create(user_id: user.id, title: params[:title], photo: params[:photo])
+  # if params[:photo] != ""
+  #   new_survey.photo = params[:photo]
+  # end
   question = new_survey.questions.create(text: params[:question]) #modify logic here if mutliple questions
   params[:choices].reject! { |key, choice| choice[:text] == "" }
   params[:choices].values.each do |choice|

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -17,4 +17,8 @@ class Survey < ActiveRecord::Base
     return "#{times} people"
   end
 
+  def has_photo?
+    self.photo != nil
+  end
+
 end

--- a/app/views/surveys/new.erb
+++ b/app/views/surveys/new.erb
@@ -7,6 +7,7 @@
       <tr><td>choice:</td><td><input type="text" name="choices[1][text]" size="20" autocorrect="off" autocapitalize="off"></td></tr>
       <tr><td>choice:</td><td><input type="text" name="choices[2][text]" size="20" autocorrect="off" autocapitalize="off"></td></tr>
       <tr><td>choice:</td><td><input type="text" name="choices[3][text]" size="20" autocorrect="off" autocapitalize="off"></td></tr>
+      <tr><td>Optional: Add a photo URL:</td><td><input type="text" name="photo" size="20" autocorrect="off" autocapitalize="off"</td></tr>
     </table>
     <input type="submit" value="create"></form>
   </form>

--- a/app/views/surveys/show.erb
+++ b/app/views/surveys/show.erb
@@ -1,6 +1,10 @@
 <%= @survey.title %>
 
-<h5><% @survey.questions.first.text %></h5>
+<% if @survey.has_photo? %>
+<div><img src="<%=@survey.photo%>" alt="<%=@survey.title%>" width="300"></div>
+<%end%>
+
+<h5><%= @survey.questions.first.text %></h5>
 <form method="post" action="/surveys/<%= URI.escape(@survey.title, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")) %>">
   <ul>
     <% @survey.questions.first.choices.each do |choice| %>

--- a/db/migrate/20151011141950_add_photo_column_to_survey_table.rb
+++ b/db/migrate/20151011141950_add_photo_column_to_survey_table.rb
@@ -1,0 +1,5 @@
+class AddPhotoColumnToSurveyTable < ActiveRecord::Migration
+  def change
+    add_column :surveys, :photo, :string
+  end
+end


### PR DESCRIPTION
- there's an optional url field to add a photo when you create a survey now
- I added a photo column to the survey table where we will store this value
- if the photo column is not empty, the photo displays for each survey. If the photo column is empty, the survey displays per usual. 

** I do not have our app validating if an image URL is valid. That means that if someone puts in "jdfklas" as their image URL, the survey displays a bad image url block. I will aim to add some validation constraints tonight.